### PR TITLE
feat. 한국 수출입 은행 open API를 활용한 환율 정보 노출 기능구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
         "recoil": "^0.7.7",
+        "recoil-persist": "^4.2.0",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.9",
         "web-vitals": "^2.1.4"
@@ -14883,6 +14884,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/recursive-readdir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "front",
   "version": "0.1.0",
   "private": true,
+  "proxy": "https://www.koreaexim.go.kr",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
@@ -17,6 +18,7 @@
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^4.2.0",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.9",
     "web-vitals": "^2.1.4"

--- a/frontend/src/pages/Info/Info.js
+++ b/frontend/src/pages/Info/Info.js
@@ -1,62 +1,72 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from '../../components/Header/header';
 import Footer from '../../components/Footer/footer';
 import { RateWrap, TodayWrap, Wrap } from './styles';
 import { Title } from '../../components/Fonts/fonts';
+import axios from 'axios';
+import { useRecoilState } from 'recoil';
+import { rate } from '../../store/userInfo';
 
 function Info() {
-  // Exchange rate by country
-  const ExchangeRate = [
-    {
-      country: '미국',
-      code: 'USD',
-      rate: '0.75',
-      symbol: '$',
-    },
-    {
-      country: '일본',
-      code: 'JPY',
-      rate: '100.78',
-      symbol: '¥',
-    },
-    {
-      country: '중국',
-      code: 'CNY',
-      rate: '5.19',
-      symbol: '¥',
-    },
-    {
-      country: '유럽',
-      code: 'EUR',
-      rate: '0.69',
-      symbol: '€',
-    },
-  ];
+  //한국 수출입은행에 api 요청
+  const request = `/site/program/financial/exchangeJSON?authkey=${process.env.REACT_APP_API_AUTHKEY}&data=AP01`;
+
+  //한국 수출입은행의 open api를 활용한 환율 정보 받아오기
+  // const [allRate, setAllRate] = useRecoilState(rate); // Exchange rate by country
+  //
+  // useEffect(() => {
+  //   if (allRate.length === 0) {
+  //     const getExchageRate = async () => {
+  //       await axios
+  //         .get(request)
+  //         .then((response) => {
+  //           if (response.data[0].result === 4) {
+  //             alert(
+  //               'api의 일일 제한횟수 마감으로 데이터를 반환할 수 없습니다.',
+  //             );
+  //             return;
+  //           }
+  //           setAllRate(response.data);
+  //         })
+  //         .catch((error) => {
+  //           console.log(error);
+  //         });
+  //     };
+  //     getExchageRate();
+  //   }
+  // });
+
   return (
     <div>
       <Header title={'exchange-rate'} />
       <Wrap>
         <TodayWrap>
           <div>
-            <div>대한민국(KRW)</div>
-            <Title margin={'8px 0'}>1,000원</Title>
-          </div>
-          <div>
             <div>오늘</div>
             <Title margin={'8px 0'}>2023.05.12</Title>
           </div>
         </TodayWrap>
         <RateWrap>
-          {ExchangeRate.map((i, key) => (
-            <div key={key}>
-              <div>
-                {i.country}({i.code})
-              </div>
-              <div>
-                {i.rate} {i.symbol}
-              </div>
-            </div>
-          ))}
+          <table border="1" width="100%">
+            <thead>
+              <tr align="center" bgcolor="white">
+                <th>국가/통화명(통화코드)</th>
+                <th>전신환(송금) 받을때</th>
+                <th>전신환(송금) 보낼때</th>
+              </tr>
+            </thead>
+            <tbody>
+              {/*{allRate.map((i, idx) => (*/}
+              {/*  <tr align="center" bgcolor="white" key={idx}>*/}
+              {/*    <td>*/}
+              {/*      {i.cur_nm}({i.cur_unit})*/}
+              {/*    </td>*/}
+              {/*    <td>{i.ttb}</td>*/}
+              {/*    <td>{i.tts}</td>*/}
+              {/*  </tr>*/}
+              {/*))}*/}
+            </tbody>
+          </table>
         </RateWrap>
       </Wrap>
       <Footer />

--- a/frontend/src/store/userInfo.js
+++ b/frontend/src/store/userInfo.js
@@ -1,6 +1,14 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+const { persistAtom } = recoilPersist();
 
 export const email = atom({
   key: 'email',
   default: '',
+});
+
+export const rate = atom({
+  key: 'rate',
+  default: [],
+  effects_UNSTABLE: [persistAtom], //새로고침 시에도 유지되도록
 });


### PR DESCRIPTION
기능 구현은 완료하였으나 api의 일일 제한횟수 마감으로 함수연결이 완료 되지 않았습니다.
횟수가 풀리면 다시 연결예정입니다.

api를 한 번 요청하면 recoil을 사용하여 저장하며 recoil-persist를 사용하여 localStorage에 저장되어 새로고침 시에도 데이터를 다시 요청하는 것이 아니라 저장되어있는 데이터를 가져오도록 구현하였습니다. 
아직 localStorage의 expired time을 설정하지 않아 이후 함수연결 시에 같이 구현하도록 하겠습니다.